### PR TITLE
Add Backyard Pokédex front-page POC and GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,37 @@
+name: Deploy static front page to GitHub Pages
+
+on:
+  push:
+    branches: ["main", "work"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,5 +1,25 @@
 # helloword
 
-Planning documentation for a family-friendly Backyard Pokédex app is available here:
+This repo now includes a first-page POC landing page for the Backyard Pokédex concept.
+
+## Run locally
+
+Open `index.html` directly in your browser, or run:
+
+```bash
+python3 -m http.server 8080
+```
+
+Then visit `http://localhost:8080`.
+
+## Deploy online
+
+A GitHub Actions workflow is included at `.github/workflows/deploy-pages.yml` to deploy this site to GitHub Pages on pushes to `main` or `work`.
+
+After the workflow runs, your site URL will be:
+
+- `https://<your-github-username>.github.io/<repository-name>/`
+
+Planning documentation for the full app remains available at:
 
 - `docs/backyard-pokedex-app-plan.md`

--- a/README.md
+++ b/README.md
@@ -12,6 +12,27 @@ python3 -m http.server 8080
 
 Then visit `http://localhost:8080`.
 
+## Database persistence (Supabase)
+
+The waitlist form now saves submitted emails to a database table via the Supabase REST API.
+
+### 1) Create the table and policy
+
+Run the SQL in:
+
+- `database/waitlist_signups.sql`
+
+This creates `public.waitlist_signups` and an RLS insert policy for `anon`.
+
+### 2) Configure client keys
+
+1. Copy `config.example.js` to `config.js`
+2. Set:
+   - `supabaseUrl`
+   - `supabaseAnonKey`
+
+> `config.js` is used by the front-end form submission logic in `app.js`.
+
 ## Deploy online
 
 A GitHub Actions workflow is included at `.github/workflows/deploy-pages.yml` to deploy this site to GitHub Pages on pushes to `main` or `work`.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,70 @@
+(function () {
+  const form = document.getElementById("waitlist-form");
+  const emailInput = document.getElementById("email");
+  const feedback = document.getElementById("form-feedback");
+  const submitButton = document.getElementById("waitlist-submit");
+
+  const config = window.APP_CONFIG || {};
+
+  function setFeedback(message, type) {
+    feedback.textContent = message;
+    feedback.classList.remove("success", "error", "info");
+    feedback.classList.add(type);
+  }
+
+  async function createWaitlistSignup(email) {
+    const url = config.supabaseUrl;
+    const key = config.supabaseAnonKey;
+    const table = config.waitlistTable || "waitlist_signups";
+
+    if (!url || !key) {
+      throw new Error("Waitlist persistence is not configured yet.");
+    }
+
+    const endpoint = `${url.replace(/\/$/, "")}/rest/v1/${table}`;
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        apikey: key,
+        Authorization: `Bearer ${key}`,
+        Prefer: "return=minimal",
+      },
+      body: JSON.stringify({
+        email,
+        source: "landing-page",
+      }),
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(errorBody || "Unable to save your signup.");
+    }
+  }
+
+  form.addEventListener("submit", async function (event) {
+    event.preventDefault();
+    const email = emailInput.value.trim().toLowerCase();
+
+    if (!email) {
+      setFeedback("Please enter an email address.", "error");
+      return;
+    }
+
+    submitButton.disabled = true;
+    submitButton.textContent = "Saving...";
+    setFeedback("Saving your signup...", "info");
+
+    try {
+      await createWaitlistSignup(email);
+      form.reset();
+      setFeedback("Thanks! You're on the waitlist.", "success");
+    } catch (error) {
+      console.error(error);
+      setFeedback("Could not save signup right now. Please try again shortly.", "error");
+    } finally {
+      submitButton.disabled = false;
+      submitButton.textContent = "Notify me";
+    }
+  });
+})();

--- a/config.example.js
+++ b/config.example.js
@@ -1,0 +1,5 @@
+window.APP_CONFIG = {
+  supabaseUrl: "https://YOUR_PROJECT_REF.supabase.co",
+  supabaseAnonKey: "YOUR_SUPABASE_ANON_KEY",
+  waitlistTable: "waitlist_signups",
+};

--- a/config.js
+++ b/config.js
@@ -1,0 +1,5 @@
+window.APP_CONFIG = {
+  supabaseUrl: "",
+  supabaseAnonKey: "",
+  waitlistTable: "waitlist_signups",
+};

--- a/database/waitlist_signups.sql
+++ b/database/waitlist_signups.sql
@@ -1,0 +1,29 @@
+-- Run in Supabase SQL editor
+create table if not exists public.waitlist_signups (
+  id uuid primary key default gen_random_uuid(),
+  email text not null unique,
+  source text not null default 'landing-page',
+  created_at timestamptz not null default now()
+);
+
+alter table public.waitlist_signups enable row level security;
+
+-- Allow anyone using the anon key to insert a waitlist signup.
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'waitlist_signups'
+      and policyname = 'allow_waitlist_insert_anon'
+  ) then
+    create policy allow_waitlist_insert_anon
+      on public.waitlist_signups
+      for insert
+      to anon
+      with check (true);
+  end if;
+end $$;
+
+-- Optional: keep reads restricted to service role only (default with no select policy).

--- a/index.html
+++ b/index.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Backyard Pokédex | Family Nature Explorer</title>
+    <meta
+      name="description"
+      content="Backyard Pokédex is a family-friendly app concept to discover, identify, and track backyard wildlife together."
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="hero">
+      <nav class="top-nav">
+        <span class="brand">🌿 Backyard Pokédex</span>
+        <a class="button ghost" href="#waitlist">Join waitlist</a>
+      </nav>
+
+      <div class="hero-content">
+        <p class="eyebrow">POC · Front page</p>
+        <h1>Turn backyard moments into family discoveries.</h1>
+        <p class="subtitle">
+          A playful, kid-friendly way to capture bugs, birds, and tiny backyard adventures while parents stay in control.
+        </p>
+        <div class="cta-row">
+          <a class="button primary" href="#features">Explore features</a>
+          <a class="button secondary" href="#vision">See app vision</a>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <section id="features" class="section">
+        <h2>What families can do</h2>
+        <div class="card-grid">
+          <article class="card">
+            <h3>📸 Quick capture</h3>
+            <p>Snap a photo in seconds and save observations with notes, behavior tags, and optional location.</p>
+          </article>
+          <article class="card">
+            <h3>🧠 Smart species hints</h3>
+            <p>Get top candidate matches for each sighting, then let a parent confirm the final species.</p>
+          </article>
+          <article class="card">
+            <h3>🏅 Progress and badges</h3>
+            <p>Unlock species cards, earn fun badges, and keep kids motivated with seasonal discovery goals.</p>
+          </article>
+        </div>
+      </section>
+
+      <section id="vision" class="section alt">
+        <h2>Built for learning and safety</h2>
+        <ul>
+          <li>Private-by-default family profiles.</li>
+          <li>Parent controls for sharing and privacy settings.</li>
+          <li>Real-world nature learning with age-appropriate design.</li>
+        </ul>
+      </section>
+
+      <section id="waitlist" class="section">
+        <h2>Stay updated</h2>
+        <p>This is an initial proof-of-concept landing page. Full product flows are coming next.</p>
+        <form class="waitlist-form" onsubmit="event.preventDefault(); alert('Thanks! We\'ll keep you posted.');">
+          <label for="email" class="sr-only">Email address</label>
+          <input id="email" type="email" placeholder="Parent email" required />
+          <button type="submit" class="button primary">Notify me</button>
+        </form>
+      </section>
+    </main>
+
+    <footer>
+      <small>© 2026 Backyard Pokédex POC</small>
+    </footer>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -61,16 +61,20 @@
       <section id="waitlist" class="section">
         <h2>Stay updated</h2>
         <p>This is an initial proof-of-concept landing page. Full product flows are coming next.</p>
-        <form class="waitlist-form" onsubmit="event.preventDefault(); alert('Thanks! We\'ll keep you posted.');">
+        <form class="waitlist-form" id="waitlist-form">
           <label for="email" class="sr-only">Email address</label>
-          <input id="email" type="email" placeholder="Parent email" required />
-          <button type="submit" class="button primary">Notify me</button>
+          <input id="email" name="email" type="email" placeholder="Parent email" required />
+          <button type="submit" class="button primary" id="waitlist-submit">Notify me</button>
         </form>
+        <p class="form-feedback" id="form-feedback" role="status" aria-live="polite"></p>
       </section>
     </main>
 
     <footer>
       <small>© 2026 Backyard Pokédex POC</small>
     </footer>
+
+    <script src="config.js"></script>
+    <script src="app.js"></script>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -7,6 +7,8 @@
   --primary: #2f9e44;
   --primary-dark: #237534;
   --border: #d8eadb;
+  --error: #b42318;
+  --success: #166534;
 }
 
 * {
@@ -110,6 +112,11 @@ h1 {
   cursor: pointer;
 }
 
+.button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .primary {
   background: var(--primary);
   color: white;
@@ -140,6 +147,24 @@ h1 {
   border-radius: 10px;
   padding: 0.65rem 0.8rem;
   font-size: 1rem;
+}
+
+.form-feedback {
+  min-height: 1.25rem;
+  margin-top: 0.75rem;
+  font-size: 0.95rem;
+}
+
+.form-feedback.info {
+  color: var(--muted);
+}
+
+.form-feedback.success {
+  color: var(--success);
+}
+
+.form-feedback.error {
+  color: var(--error);
 }
 
 footer {

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,161 @@
+:root {
+  color-scheme: light;
+  --bg: #f5fbf6;
+  --surface: #ffffff;
+  --text: #173322;
+  --muted: #42624e;
+  --primary: #2f9e44;
+  --primary-dark: #237534;
+  --border: #d8eadb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.5;
+}
+
+.hero {
+  background: linear-gradient(145deg, #dbf5e2, #f5fbf6);
+  padding: 1rem 1.25rem 4rem;
+}
+
+.top-nav {
+  max-width: 1080px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.brand {
+  font-weight: 700;
+}
+
+.hero-content {
+  max-width: 760px;
+  margin: 3rem auto 0;
+  text-align: center;
+}
+
+.eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--muted);
+  font-weight: 600;
+  font-size: 0.8rem;
+}
+
+h1 {
+  font-size: clamp(2rem, 4vw, 3.3rem);
+  line-height: 1.12;
+  margin-bottom: 0.8rem;
+}
+
+.subtitle {
+  color: var(--muted);
+  font-size: 1.05rem;
+  margin: 0 auto;
+  max-width: 620px;
+}
+
+.cta-row {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.section {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 2.75rem 1.25rem;
+}
+
+.alt {
+  background: #eef8f1;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+
+.card-grid {
+  margin-top: 1rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem;
+}
+
+.button {
+  display: inline-block;
+  text-decoration: none;
+  border-radius: 10px;
+  padding: 0.65rem 1rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+  cursor: pointer;
+}
+
+.primary {
+  background: var(--primary);
+  color: white;
+}
+
+.primary:hover {
+  background: var(--primary-dark);
+}
+
+.secondary,
+.ghost {
+  border-color: var(--border);
+  color: var(--text);
+  background: white;
+}
+
+.waitlist-form {
+  margin-top: 1rem;
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.waitlist-form input {
+  flex: 1;
+  min-width: 220px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.65rem 0.8rem;
+  font-size: 1rem;
+}
+
+footer {
+  border-top: 1px solid var(--border);
+  text-align: center;
+  padding: 1rem;
+  color: var(--muted);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}


### PR DESCRIPTION
### Motivation
- Provide a presentable proof-of-concept landing page for the Backyard Pokédex concept so the project can be shared and reviewed immediately.
- Enable a simple path to publish the static front page online via GitHub Pages using Actions for automated deployment.

### Description
- Add a static front-page POC (`index.html`) with hero, feature cards, vision section, and a waitlist form for immediate presentation. 
- Add styling (`styles.css`) for responsive layout, colors, CTA/button styles, and card/grid layout. 
- Add a deployment workflow (`.github/workflows/deploy-pages.yml`) to deploy the repository to GitHub Pages on pushes to `main` or `work`.
- Update `README.md` with local run instructions (`python3 -m http.server 8080`) and the expected GitHub Pages URL pattern.

### Testing
- Started a local HTTP server with `python3 -m http.server 8080` and verified `curl -I http://127.0.0.1:8080/index.html` returned HTTP 200 (succeeded).
- Performed a repository commit and verified working tree status with `git status --short` (succeeded).
- The GitHub Actions Pages workflow was added but not executed in this environment, so remote Pages deployment remains to be validated after pushing the branch (not run here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec6c6d4480833183f648bea695ed7a)